### PR TITLE
Redesign 3: Add new functions and error handlers

### DIFF
--- a/src/SIM800-AT.cpp
+++ b/src/SIM800-AT.cpp
@@ -206,6 +206,17 @@ int GPRS::enable_bearer(char *resp_buf, int size_buf)
     return 0;
 }
 
+int GPRS::get_active_network(char *resp_buf, int size_buf)
+{
+    send_cmd("AT+COPS?");
+    read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, NULL);
+    if ((NULL != strstr(resp_buf,"OK"))) {
+        return 0; // Success
+    }
+    // Invalid or no response
+    return -1;
+}
+
 void GPRS::search_networks(void)
 {
     send_cmd("AT+COPS=?");
@@ -437,7 +448,7 @@ int GPRS::send_tcp_data(unsigned char *data, int len, char *resp_buf, int size_b
         gprsSerial.putc(data[i]);
     }
 
-    read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, NULL);
+    read_resp(resp_buf, size_buf, 7, NULL);
     if (NULL == strstr(resp_buf,"OK")) {
         return -1;
     }

--- a/src/SIM800-AT.cpp
+++ b/src/SIM800-AT.cpp
@@ -200,7 +200,6 @@ int GPRS::enable_bearer(char *resp_buf, int size_buf)
 {
     send_cmd("AT+SAPBR=1,1");
     if (0 != read_resp(resp_buf, size_buf, 6, "OK")) {
-        disable_bearer(resp_buf, size_buf);
         return -1;
     }
     // If the responses are as expected
@@ -380,10 +379,11 @@ int GPRS::close_tcp(char *resp_buf, int size_buf)
     // closes the TCP connection
     send_cmd("AT+CIPCLOSE=0");
     read_resp(resp_buf, size_buf, 6, NULL);
-    if (NULL != strstr(resp_buf,"CLOSE OK")) {
+    if ((NULL != strstr(resp_buf,"CLOSE OK")) || 
+        (NULL != strstr(resp_buf,"ERROR"))) { // If TCP not opened previously
         return 0; // Success
     }
-    return -1; // Invalid or ERROR
+    return -1; // Invalid
 }
 
 int GPRS::close_tcp_quick(char *resp_buf, int size_buf)
@@ -391,10 +391,11 @@ int GPRS::close_tcp_quick(char *resp_buf, int size_buf)
     // closes the TCP connection quickly
     send_cmd("AT+CIPCLOSE=1");
     read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, NULL);
-    if (NULL != strstr(resp_buf,"CLOSE OK")) {
+    if ((NULL != strstr(resp_buf,"CLOSE OK")) || 
+        (NULL != strstr(resp_buf,"ERROR"))) { // If TCP not opened previously
         return 0; // Success
     }
-    return -1; // Invalid or ERROR
+    return -1; // Invalid
 }
 
 int GPRS::detach_gprs(char *resp_buf, int size_buf)

--- a/src/SIM800-AT.h
+++ b/src/SIM800-AT.h
@@ -172,8 +172,8 @@ public:
      * The modem may return ERROR if TCP is not already opened.
      * @param resp_buf Pointer to the buffer that will store the received data
      * @param size_buf Size of the receive buffer
-     * @return Returns -1 on receiving an ERROR or invalid response.
-     * Returns 0 if CLOSE OK is received from the modem.
+     * @return Returns -1 on receiving an invalid response.
+     * Returns 0 if CLOSE OK or ERROR received from the modem.
      */
     int close_tcp(char *resp_buf, int size_buf);
 
@@ -184,8 +184,8 @@ public:
      * The modem may return ERROR if TCP is not already opened.
      * @param resp_buf Pointer to the buffer that will store the received data
      * @param size_buf Size of the receive buffer
-     * @return Returns -1 on receiving an ERROR or invalid response.
-     * Returns 0 if CLOSE OK is received from the modem.
+     * @return Returns -1 on receiving an invalid response.
+     * Returns 0 if CLOSE OK or ERROR received from the modem.
      */
     int close_tcp_quick(char *resp_buf, int size_buf);
 

--- a/src/SIM800-AT.h
+++ b/src/SIM800-AT.h
@@ -93,6 +93,15 @@ public:
     int enable_bearer(char *resp_buf, int size_buf);
 
     /**
+     * Check the current bearer status sending the command "AT+SAPBR=2,1"
+     * to the GSM modem.
+     * @return Returns -1 if invalid or no response from the modem.
+     * 0 = Bearer is connecting, 1 = Bearer is connected, 2 = Bearer is closing
+     * 3 = Bearer is closed
+     */
+    int check_bearer_status(void);
+
+    /**
      * Check GSM registration.
      * The function sends the AT command "AT+CREG?" to the GSM modem.
      * @param resp_buf Pointer to the buffer that will store the received data
@@ -138,9 +147,11 @@ public:
     /**
      * Bring Up Wireless Connection with GPRS.
      * The function sends the AT commands "AT+CIICR" to the GSM modem.
+     * If this was setup already, the modem will respond with "ERROR", and this 
+     * is actually not an error.
      * @param resp_buf Pointer to the buffer that will store the received data
      * @param size_buf Size of the receive buffer
-     * @return Returns 0 if the modem responds with "OK".
+     * @return Returns 0 if the modem responds with "OK" or "ERROR".
      * Returns -1 if no response or invalid.
      */
     int activate_gprs(char *resp_buf, int size_buf);
@@ -192,8 +203,10 @@ public:
     /**
      * Closes the GPRS PDP context.
      * The function sends the AT command "AT+CIPSHUT" to the GSM modem.
+     * @return Returns -1 on receiving an invalid response.
+     * Returns 0 if SHUT OK received from the modem.
      */
-    void close_pdp_context(void);
+    int close_pdp_context(void);
 
     int detach_gprs(char *resp_buf, int size_buf);
     int disable_bearer(char *resp_buf, int size_buf);
@@ -237,9 +250,10 @@ public:
     void search_networks(void);
 
     /**
-     * Function to manually switch to a specific available network.
-     * This function sends the command (AT+COPS=1,1,"OperatorShortName").
-     * This can take upto 3 minutes to get a response. 
+     * Function to manually switch to a specific available network and then 
+     * switches back to auto mode if the manual selection fails.
+     * This function sends the command (AT+COPS=4,1,"OperatorShortName").
+     * This can take upto 2 minutes to get a response. 
      * So, need to be careful about a watchdog reset in the main program.
      * Immediate response-check is also handled in the function.
      * @param resp_buf Pointer to the buffer that will store the received data

--- a/src/SIM800-AT.h
+++ b/src/SIM800-AT.h
@@ -220,6 +220,15 @@ public:
     bool get_location(float *latitude, float *longitude, char *resp_buf, int size_buf);
 
     /**
+     * Get the currently selected network operator.
+     * This function sends the command "AT+COPS?" to the modem.
+     * @param resp_buf Pointer to the buffer that will store the received data
+     * @param size_buf Size of the receive buffer
+     * @return Returns -1 if invalid or no response from the modem, and 0 if success
+     */
+    int get_active_network(char *resp_buf, int size_buf);
+
+    /**
      * This function only sends the command (AT+COPS=?) for searching the available networks.
      * Reading the response must be done separately using the read_resp() function.
      * It can take upto 3 minutes to get a response.


### PR DESCRIPTION
Add new functions to get the current network information, check bearer status.
Modify enable bearer and TCP close functions. 
Bearer and GPRS error handlers updated. 
Update the function activate_gprs() to handle ERROR response.
Check the actual bearer status before retry.
If bearer is already open and an ERROR response received, do not consider this as an error.
Update select_network() function to automatically switch to the 'automatic network registration mode' on a failed attempt to register manually.