### PR TITLE
Add configurable timeout in send_tcp_data()

### DIFF
--- a/src/SIM800-AT.cpp
+++ b/src/SIM800-AT.cpp
@@ -521,7 +521,7 @@ void GPRS::sleep(void)
     send_cmd("AT+CSCLK=2");
 }
 
-int GPRS::send_tcp_data(unsigned char *data, int len, char *tcp_buf, int size_buf)
+int GPRS::send_tcp_data(unsigned char *data, int len, char *tcp_buf, int size_buf, uint8_t timeout)
 {
     char cmd[64];
     snprintf(cmd, sizeof(cmd), "AT+CIPSEND=%d", len);
@@ -539,7 +539,7 @@ int GPRS::send_tcp_data(unsigned char *data, int len, char *tcp_buf, int size_bu
 #endif
     }
     // The response could take longer than 7 seconds, it depends on the connection to the server
-    read_resp(tcp_buf, size_buf, 7, NULL);
+    read_resp(tcp_buf, size_buf, timeout, NULL);
     if (NULL == strstr(tcp_buf, "OK")) {
         return MODEM_RESPONSE_ERROR;
     }

--- a/src/SIM800-AT.h
+++ b/src/SIM800-AT.h
@@ -225,7 +225,7 @@ public:
     int detach_gprs(char *resp_buf, int size_buf);
     int disable_bearer(char *resp_buf, int size_buf);
     void sleep(void);
-    int send_tcp_data(unsigned char *data, int len, char *resp_buf, int size_buf);
+    int send_tcp_data(unsigned char *data, int len, char *resp_buf, int size_buf, uint8_t timeout);
     int check_ssl_cert(const char *filename, int filesize, char *resp_buf, int size_buf);
     int load_ssl(const char *filename, const char *cert, int filesize, char *resp_buf, int size_buf);
     int reset(char *resp_buf, int size_buf);


### PR DESCRIPTION
New argument to the function send_tcp_data(). Timeout values are now passed to send_tcp_data(). 