### PR TITLE
Redesign the UART communication using interrupts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_include_directories(src)
 
-target_sources(app PRIVATE src/SIM800-AT.cpp)
+target_sources(app PRIVATE src/SIM800-AT-Zephyr.cpp)

--- a/src/SIM800-AT-Zephyr.cpp
+++ b/src/SIM800-AT-Zephyr.cpp
@@ -27,123 +27,240 @@
 #include <time.h>
 
 #define UART_GSM DT_LABEL(DT_ALIAS(uart_uext))
-
 struct device *gsm_dev = device_get_binding(UART_GSM);
+
+int time_out = DEFAULT_TIMEOUT;
+char ack_message[32];
+uint32_t time_initial;
+uint16_t actual_ack_num_bytes;
+volatile size_t current_index = 0;
+static volatile bool ack_received = false;
+char resp_buf[BUF_SIZE_DEFAULT]; // The size need to be tuned
 
 int GPRS::request_data(void)
 {
-    send_cmd("AT+CIPRXGET=2,100");
+    send_cmd("AT+CIPRXGET=2,100", DEFAULT_TIMEOUT, NULL);
+    k_sleep(K_SECONDS(DEFAULT_TIMEOUT));
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::read_resp(char *resp_buf, int size_buf, int time_out, const char *ack_message)
+void read_resp(void* user_data)
 {
-    uint32_t t1 = k_uptime_get() / 1000;
-    int index_buf = 0;
-    int exp_ack_num_bytes = strlen(ack_message);
-    int actual_ack_num_bytes = 0;
+    uint8_t c;
+    bool exit_flag = false;
 
-    while (((k_uptime_get() / 1000) - t1) <= time_out) { // timer not expired yet
-        if (index_buf < size_buf-1) {
-            if (uart_poll_in(gsm_dev, (unsigned char *)&resp_buf[index_buf]) == 0) {
-                if (ack_message != NULL) { //Decide if an acknowledgement check required
+    if (!uart_irq_update(gsm_dev)) {
+        return;
+    }
+
+    if (((k_uptime_get() / 1000) - time_initial) <= time_out) { // timer not expired yet
+        while (uart_irq_rx_ready(gsm_dev)) {
+            uart_fifo_read(gsm_dev, &c, 1);
+            // Fill the buffer up to all but 1 character (the last character is reserved for '\0')
+            // Characters beyond the size of the buffer are dropped.
+            if (current_index < (BUF_SIZE_DEFAULT - 1)) {
+                // There is always one last character left for the '\0'
+                resp_buf[current_index] = c;
+
+                if (strlen(ack_message) != 0) { //Decide if an acknowledgement check required
                     // Checks if the acknowledgement string is received correctly
-                    if (resp_buf[index_buf] == ack_message[actual_ack_num_bytes]) {
+                    if (resp_buf[current_index] == ack_message[actual_ack_num_bytes]) {
                         actual_ack_num_bytes++;
                     }
                     else {
                         actual_ack_num_bytes = 0; // Reset the counter
                     }
 
-                    if (actual_ack_num_bytes == exp_ack_num_bytes) { // Exit condition
-                        resp_buf[0] = '\0'; // Null char to clear the buffer
-                        return MODEM_RESPONSE_OK;
+                    if (actual_ack_num_bytes == strlen(ack_message)) { // Exit condition
+                        // Acknowledgement string received
+                        current_index++;
+                        ack_received = true;
+                        exit_flag = true;
+                        goto exit;
                     }
                 }
-                index_buf++; // Only increments if a byte received
+                current_index++;
             }
-        }
-        else { // If the received number of bytes reached the maximum expected size.
-            resp_buf[index_buf] = '\0'; // Add a null char at the end of the received data
-            return MODEM_RESPONSE_ERROR; // This is actually not an invalid response
-        }
+            else { // Buffer exceeded
+                exit_flag = true;
+                goto exit;
+            }
+        } // While data receive
     }
-    // If timed-out
-    resp_buf[index_buf] = '\0'; // Add a null char at the end of the received data
-    return MODEM_RESPONSE_ERROR;
+    else { // If timed out
+        exit_flag = true;
+    }
+exit:
+    if (exit_flag) {
+        uart_irq_rx_disable(gsm_dev);
+        resp_buf[current_index] = '\0';
+    }
+    return;
 }
 
-void GPRS::send_cmd(const char *cmd)
+void init_modem(void)
+{
+    uart_irq_callback_user_data_set(gsm_dev, read_resp, NULL);
+}
+
+void GPRS::send_cmd(const char *cmd, int timeout, const char *ack)
 {
     for (int i = 0; i < (int)strlen(cmd); i++) {
-            uart_poll_out(gsm_dev, cmd[i]);
-        }
+        uart_poll_out(gsm_dev, cmd[i]);
+    }
     uart_poll_out(gsm_dev, '\r');
     uart_poll_out(gsm_dev, '\n');
+
+    // Prepare for processing in the receive interrupt
+    prepare_for_rx(timeout, ack);
 }
 
-int GPRS::init(char *resp_buf, int size_buf)
+// Call this only after sending a command to the SIM800.
+// Resets the necessary variables and enables the Rx interrupt
+void GPRS::prepare_for_rx(int timeout, const char *ack)
+{
+    ack_message[0] = '\0';
+    // Make the ack_message configurable
+    if (strlen(ack) > sizeof(ack_message) - 1) {
+        printf("Invalid string length for ACK \n");
+    }
+    else {
+        if (ack != NULL) {
+            strncpy(ack_message, ack, sizeof(ack_message));
+        }
+        // Else, the ack_message will be empty anyway.
+    }
+
+    // To handle a special case of early exit from the ISR while using the NULL argument,
+    // as described in send_cmd().
+    if (ack == NULL) {
+        // We are reusing the buffer, so clear it before the reuse
+        memset(resp_buf, 0, sizeof(resp_buf));
+    }
+
+    ack_received = false;
+    time_out = timeout;
+    time_initial = k_uptime_get() / 1000; // Set the initial value for timeout check
+    current_index = 0;  // Do this here instead of doing in the ISR. This to handle a special case,
+                        // when the modem response comes faster and NULL is used as an Ack string.
+    resp_buf[0] = '\0';
+    actual_ack_num_bytes = 0;
+    uart_irq_rx_enable(gsm_dev);
+}
+
+int GPRS::init(void)
 {
     for (int i = 0; i < 3; i++) {
-        send_cmd("AT");
-        if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+        send_cmd("AT", DEFAULT_TIMEOUT, "OK");
+        k_sleep(K_SECONDS(1));
+        if (ack_received == false) {
+            printf("\r\nFailed init_resp\r\n");
             return MODEM_RESPONSE_ERROR;
         }
     }
 
-    // Disable modem echo
-    send_cmd("ATE0");
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    // Disable modem echo.
+    send_cmd("ATE0", DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
     // If the response is as expected
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::wakeup(char *resp_buf, int size_buf)
+int GPRS::wakeup(void)
 {
-    send_cmd("AT");
-    send_cmd("AT+CSCLK=0");
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    send_cmd("AT", 1, NULL);
+    k_sleep(K_SECONDS(1));
+    send_cmd("AT+CSCLK=0", DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
+        printf("\r\nFailed wakeup\r\n");
         return MODEM_RESPONSE_ERROR;
     }
+
     // If the response is as expected
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::check_pin(char *resp_buf, int size_buf)
+int GPRS::check_pin(void)
 {
-    send_cmd("AT+CPIN?");
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "READY")) {
+    send_cmd("AT+CPIN?", DEFAULT_TIMEOUT, "READY");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
+        printf("\r\nFailed check_pin\r\n");
         return MODEM_RESPONSE_ERROR;
     }
     // If the response is as expected
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::set_pin(const char* pin, char *resp_buf, int size_buf)
+int GPRS::set_pin(const char* pin)
 {
     char cpin[20];
     sprintf(cpin, "AT+CPIN=\"%s\"", pin);
-    send_cmd(cpin);
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    send_cmd(cpin, DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
     // If the response is as expected
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::enable_ssl(const char *filename, char *resp_buf, int size_buf)
+int GPRS::check_ssl_cert(const char *filename, int filesize)
+{
+    char cmd[64];
+    char resp[64];
+    snprintf(cmd, sizeof(cmd), "AT+FSFLSIZE=%s", filename);
+    snprintf(resp, sizeof(resp), "FSFLSIZE: %d", filesize);
+    send_cmd(cmd, DEFAULT_TIMEOUT, resp);
+    k_sleep(K_SECONDS(1));
+
+    if (ack_received == false) {
+        return MODEM_RESPONSE_ERROR;
+    }
+
+    // If the response is as expected
+    return MODEM_RESPONSE_OK;
+}
+
+int GPRS::load_ssl(const char *filename, const char *cert, int filesize)
+{
+    char cmd[64];
+    snprintf(cmd, sizeof(cmd), "AT+FSCREATE=%s", filename);
+    send_cmd(cmd, DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
+        return MODEM_RESPONSE_ERROR;
+    }
+
+    snprintf(cmd, sizeof(cmd), "AT+FSWRITE=%s,0,%d,5", filename, filesize);
+    send_cmd(cmd, DEFAULT_TIMEOUT, ">");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
+        return MODEM_RESPONSE_ERROR;
+    }
+
+    send_cmd(cert, DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
+        return MODEM_RESPONSE_ERROR;
+    }
+
+    // If the responses are as expected
+    return MODEM_RESPONSE_OK;
+}
+
+
+int GPRS::ssl_set_cert(const char *filename)
 {
     char cmd[64];
     snprintf(cmd, sizeof(cmd), "AT+SSLSETCERT=%s,ABC", filename);
-    send_cmd(cmd);
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "+SSLSETCERT: 0")) {
-        return MODEM_RESPONSE_ERROR;
-    }
-
-    send_cmd("AT+CIPSSL=1");
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    send_cmd(cmd, DEFAULT_TIMEOUT, "+SSLSETCERT: 0");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
@@ -151,20 +268,11 @@ int GPRS::enable_ssl(const char *filename, char *resp_buf, int size_buf)
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::setup_clock(char *resp_buf, int size_buf)
+int GPRS::enable_ssl(void)
 {
-    send_cmd("AT+CNTPCID=1");
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
-        return MODEM_RESPONSE_ERROR;
-    }
-
-    send_cmd("AT+CNTP=time1.google.com,0");
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
-        return MODEM_RESPONSE_ERROR;
-    }
-
-    send_cmd("AT+CNTP");
-    if (0 != read_resp(resp_buf, size_buf, 6, "+CNTP: 1")) {
+    send_cmd("AT+CIPSSL=1", DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
@@ -172,45 +280,71 @@ int GPRS::setup_clock(char *resp_buf, int size_buf)
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::setup_bearer(const char* apn, const char* user, const char* pass,
-                        char *resp_buf, int size_buf)
+int GPRS::setup_clock(void)
+{
+    send_cmd("AT+CNTPCID=1", DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
+        return MODEM_RESPONSE_ERROR;
+    }
+
+    send_cmd("AT+CNTP=time1.google.com,0", DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
+        return MODEM_RESPONSE_ERROR;
+    }
+
+    send_cmd("AT+CNTP", 6, "+CNTP: 1");
+    k_sleep(K_SECONDS(3));
+    if (ack_received == false) {
+        return MODEM_RESPONSE_ERROR;
+    }
+
+    // If the response is as expected
+    return MODEM_RESPONSE_OK;
+}
+
+int GPRS::setup_bearer(const char* apn, const char* user, const char* pass)
 {
     // Set the type of Internet connection as GPRS
     char cmd[64];
-    send_cmd("AT+SAPBR=3,1,Contype,GPRS");
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    send_cmd("AT+SAPBR=3,1,Contype,GPRS", DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
     // Set the access point name string
     snprintf(cmd, sizeof(cmd), "AT+SAPBR=3,1,APN,\"%s\"", apn);
-    send_cmd(cmd);
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    send_cmd(cmd, DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
     // Set the user name for APN
     snprintf(cmd, sizeof(cmd), "AT+SAPBR=3,1,USER,\"%s\"", user);
-    send_cmd(cmd);
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    send_cmd(cmd, DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
     // Set the password for APN
     snprintf(cmd, sizeof(cmd), "AT+SAPBR=3,1,PWD,\"%s\"", pass);
-    send_cmd(cmd);
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    send_cmd(cmd, DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
     // If the responses are as expected
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::enable_bearer(char *resp_buf, int size_buf)
+int GPRS::enable_bearer(void)
 {
-    send_cmd("AT+SAPBR=1,1"); // Response time can be upto 85 seconds
-    read_resp(resp_buf, size_buf, 6, NULL);
-
+    send_cmd("AT+SAPBR=1,1", 85, NULL); // Response time can be upto 85 seconds
+    k_sleep(K_SECONDS(2));
     if (NULL != strstr(resp_buf, "OK")) {
         return MODEM_RESPONSE_OK;
     }
@@ -230,22 +364,21 @@ int GPRS::check_bearer_status(void)
     const char delimiters[2] = ","; // Multiple delimiters to separate the string
     char *token = NULL;
     int status = -1;
-    char bearer_info[40];
 
-    send_cmd("AT+SAPBR=2,1");
-    read_resp(bearer_info, sizeof(bearer_info), DEFAULT_TIMEOUT, NULL);
-
-    if (0 == strlen(bearer_info)) {
+    send_cmd("AT+SAPBR=2,1", DEFAULT_TIMEOUT, NULL);
+    k_sleep(K_SECONDS(DEFAULT_TIMEOUT));
+    if (0 == strlen(resp_buf)) {
         return MODEM_RESPONSE_ERROR; // No response
     }
     else { // Response received
         // Response will be in the format +SAPBR: 1,1,"10.136.76.225"
         // Split the string using the set of delimiters
-        token = strtok(bearer_info, delimiters);
+        token = strtok(resp_buf, delimiters);
         while (token != NULL) {
             for (int i = 0; i < 3; i++) {
                 if (i == 1) {
                     sscanf(token, "%d", &status);
+                    printf("Bearer status: %d\n", status);
                 }
                 token = strtok(NULL, delimiters);
                 if (token == NULL) { // If the end of the list
@@ -258,10 +391,10 @@ int GPRS::check_bearer_status(void)
     return MODEM_RESPONSE_ERROR; // Invalid response
 }
 
-int GPRS::get_active_network(char *resp_buf, int size_buf)
+int GPRS::get_active_network(void)
 {
-    send_cmd("AT+COPS?");
-    read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, NULL);
+    send_cmd("AT+COPS?", DEFAULT_TIMEOUT, NULL);
+    k_sleep(K_SECONDS(1));
     if ((NULL != strstr(resp_buf, "OK"))) {
         return MODEM_RESPONSE_OK;
     }
@@ -271,15 +404,16 @@ int GPRS::get_active_network(char *resp_buf, int size_buf)
 
 void GPRS::search_networks(void)
 {
-    send_cmd("AT+COPS=?");
+    send_cmd("AT+COPS=?", 120, NULL);
 }
 
-int GPRS::select_network(const char *network, char *resp_buf, int size_buf)
+int GPRS::select_network(const char *network)
 {
     char cmd[64];
     snprintf(cmd, sizeof(cmd), "AT+COPS=4,1,\"%s\"", network);
-    send_cmd(cmd);
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    send_cmd(cmd, 120, "OK");
+    k_sleep(K_SECONDS(DEFAULT_TIMEOUT));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
@@ -287,10 +421,10 @@ int GPRS::select_network(const char *network, char *resp_buf, int size_buf)
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::network_registration_gsm(char *resp_buf, int size_buf)
+int GPRS::network_registration_gsm(void)
 {
-    send_cmd("AT+CREG?");
-    read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, NULL);
+    send_cmd("AT+CREG?", DEFAULT_TIMEOUT, NULL);
+    k_sleep(K_SECONDS(DEFAULT_TIMEOUT));
     if ((NULL != strstr(resp_buf, "+CREG: 0,1")) ||
         (NULL != strstr(resp_buf, "+CREG: 0,5"))) {
         return MODEM_RESPONSE_OK;
@@ -299,10 +433,10 @@ int GPRS::network_registration_gsm(char *resp_buf, int size_buf)
     return MODEM_RESPONSE_ERROR;
 }
 
-int GPRS::network_registration_gprs(char *resp_buf, int size_buf)
+int GPRS::network_registration_gprs(void)
 {
-    send_cmd("AT+CGREG?");
-    read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, NULL);
+    send_cmd("AT+CGREG?", DEFAULT_TIMEOUT, NULL);
+    k_sleep(K_SECONDS(DEFAULT_TIMEOUT));
     if ((NULL != strstr(resp_buf, "+CGREG: 0,1")) ||
         (NULL != strstr(resp_buf, "+CGREG: 0,5"))) {
         return MODEM_RESPONSE_OK;
@@ -311,11 +445,11 @@ int GPRS::network_registration_gprs(char *resp_buf, int size_buf)
     return MODEM_RESPONSE_ERROR;
 }
 
-int GPRS::check_signal_strength(char *resp_buf, int size_buf)
+int GPRS::check_signal_strength(void)
 {
     int value = 0;
-    send_cmd("AT+CSQ");
-    read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, NULL);
+    send_cmd("AT+CSQ", DEFAULT_TIMEOUT, NULL);
+    k_sleep(K_SECONDS(DEFAULT_TIMEOUT));
     if (0 != strlen(resp_buf)) {
         // Extract the integer value from the received string.
         sscanf(resp_buf, " +CSQ: %d,", &value);
@@ -328,11 +462,10 @@ int GPRS::check_signal_strength(char *resp_buf, int size_buf)
     return MODEM_RESPONSE_ERROR; // If no response
 }
 
-uint32_t GPRS::get_time(char *resp_buf, int size_buf)
+uint32_t GPRS::get_time(void)
 {
-    send_cmd("AT+CCLK?");
-    read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, NULL);
-
+    send_cmd("AT+CCLK?", DEFAULT_TIMEOUT, NULL);
+    k_sleep(K_SECONDS(DEFAULT_TIMEOUT));
     if (0 != strlen(resp_buf)) {
         struct tm timeinfo;
         int timezone;
@@ -358,11 +491,12 @@ uint32_t GPRS::get_time(char *resp_buf, int size_buf)
     return MODEM_RESPONSE_ERROR; // If no response
 }
 
-int GPRS::attach_gprs(char *resp_buf, int size_buf)
+int GPRS::attach_gprs(void)
 {
     // Attach GPRS
-    send_cmd("AT+CGATT=1");
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    send_cmd("AT+CGATT=1", DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
@@ -370,17 +504,19 @@ int GPRS::attach_gprs(char *resp_buf, int size_buf)
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::enable_get_data_manually(char *resp_buf, int size_buf)
+int GPRS::enable_get_data_manually(void)
 {
     // Startup single IP connection
-    send_cmd("AT+CIPMUX=0");
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    send_cmd("AT+CIPMUX=0", DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
     //Enable getting data from network manually.
-    send_cmd("AT+CIPRXGET=1");
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    send_cmd("AT+CIPRXGET=1", DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
@@ -388,21 +524,22 @@ int GPRS::enable_get_data_manually(char *resp_buf, int size_buf)
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::set_apn(const char* apn, const char* user, const char* pass, char *resp_buf, int size_buf)
+int GPRS::set_apn(const char* apn, const char* user, const char* pass)
 {
     char cmd[64];
     snprintf(cmd, sizeof(cmd), "AT+CSTT=\"%s\",\"%s\",\"%s\"", apn, user, pass);
-    send_cmd(cmd);
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    send_cmd(cmd, DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::activate_gprs(char *resp_buf, int size_buf)
+int GPRS::activate_gprs(void)
 {
-    send_cmd("AT+CIICR"); // Upto 85 seconds
-    read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, NULL);
+    send_cmd("AT+CIICR", DEFAULT_TIMEOUT, NULL); // Upto 85 seconds
+    k_sleep(K_SECONDS(DEFAULT_TIMEOUT));
     if ((NULL != strstr(resp_buf, "OK")) ||
         (NULL != strstr(resp_buf, "ERROR"))) {
         // If the responses are as expected - OK or ERROR received
@@ -412,23 +549,23 @@ int GPRS::activate_gprs(char *resp_buf, int size_buf)
     return MODEM_RESPONSE_ERROR;
 }
 
-int GPRS::get_ip(char *resp_buf, int size_buf)
+int GPRS::get_ip(void)
 {
-    send_cmd("AT+CIFSR");
-    if (0 == read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "ERROR")) {
+    send_cmd("AT+CIFSR", DEFAULT_TIMEOUT, "ERROR");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == true) {
         return MODEM_RESPONSE_ERROR;
     }
     // If the response gives a valid IP address
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::connect_tcp(const char *domain, const char *port, char *resp_buf, int size_buf)
+int GPRS::connect_tcp(const char *domain, const char *port)
 {
     char cmd[100];
     sprintf(cmd, "AT+CIPSTART=TCP,%s,%s", domain, port);
-    send_cmd(cmd);
-
-    read_resp(resp_buf, size_buf, 6, NULL);
+    send_cmd(cmd, 6, NULL);
+    k_sleep(K_SECONDS(DEFAULT_TIMEOUT));
     if ((NULL != strstr(resp_buf, "CONNECT OK")) ||
         (NULL != strstr(resp_buf, "ALREADY CONNECT"))) {
         return MODEM_RESPONSE_OK;
@@ -439,22 +576,20 @@ int GPRS::connect_tcp(const char *domain, const char *port, char *resp_buf, int 
 
 int GPRS::close_pdp_context(void)
 {
-    char buf[30];
     // Close the GPRS PDP context.
-    send_cmd("AT+CIPSHUT"); // Can take up to 65 seconds
-    read_resp(buf, sizeof(buf), 6, NULL);
-
-    if (NULL != strstr(buf, "SHUT OK")) {
+    send_cmd("AT+CIPSHUT", 6, NULL);
+    k_sleep(K_SECONDS(DEFAULT_TIMEOUT));
+    if (NULL != strstr(resp_buf, "SHUT OK")) {
         return MODEM_RESPONSE_OK;
     }
     return MODEM_RESPONSE_ERROR;
 }
 
-int GPRS::close_tcp(char *resp_buf, int size_buf)
+int GPRS::close_tcp(void)
 {
     // closes the TCP connection
-    send_cmd("AT+CIPCLOSE=0");
-    read_resp(resp_buf, size_buf, 6, NULL);
+    send_cmd("AT+CIPCLOSE=0", 6, NULL);
+    k_sleep(K_SECONDS(DEFAULT_TIMEOUT));
     if ((NULL != strstr(resp_buf, "CLOSE OK")) ||
         (NULL != strstr(resp_buf, "ERROR"))) { // If TCP not opened previously
         return MODEM_RESPONSE_OK;
@@ -462,11 +597,12 @@ int GPRS::close_tcp(char *resp_buf, int size_buf)
     return MODEM_RESPONSE_ERROR; // Invalid
 }
 
-int GPRS::close_tcp_quick(char *resp_buf, int size_buf)
+// int GPRS::close_tcp_quick(char *resp_buf, int size_buf)
+int GPRS::close_tcp_quick(void)
 {
     // closes the TCP connection quickly
-    send_cmd("AT+CIPCLOSE=1");
-    read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, NULL);
+    send_cmd("AT+CIPCLOSE=1", DEFAULT_TIMEOUT, NULL);
+    k_sleep(K_SECONDS(DEFAULT_TIMEOUT));
     if ((NULL != strstr(resp_buf, "CLOSE OK")) ||
         (NULL != strstr(resp_buf, "ERROR"))) { // If TCP not opened previously
         return MODEM_RESPONSE_OK;
@@ -474,20 +610,22 @@ int GPRS::close_tcp_quick(char *resp_buf, int size_buf)
     return MODEM_RESPONSE_ERROR; // Invalid
 }
 
-int GPRS::detach_gprs(char *resp_buf, int size_buf)
+int GPRS::detach_gprs(void)
 {
-    send_cmd("AT+CGATT=0");
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    send_cmd("AT+CGATT=0", DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
     // If the response is as expected
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::disable_bearer(char *resp_buf, int size_buf)
+int GPRS::disable_bearer(void)
 {
-    send_cmd("AT+SAPBR=0,1"); // Up to 65 seconds
-    if (0 != read_resp(resp_buf, size_buf, 6, "OK")) {
+    send_cmd("AT+SAPBR=0,1", 6, "OK"); // Up to 65 seconds
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
     // If the response is as expected
@@ -496,15 +634,17 @@ int GPRS::disable_bearer(char *resp_buf, int size_buf)
 
 void GPRS::sleep(void)
 {
-    send_cmd("AT+CSCLK=2");
+    send_cmd("AT+CSCLK=2", DEFAULT_TIMEOUT, "OK");
+    // k_sleep(K_SECONDS(1));
 }
 
-int GPRS::send_tcp_data(unsigned char *data, int len, char *tcp_buf, int size_buf, uint8_t timeout)
+int GPRS::send_tcp_data(unsigned char *data, int len, uint8_t timeout)
 {
     char cmd[64];
     snprintf(cmd, sizeof(cmd), "AT+CIPSEND=%d", len);
-    send_cmd(cmd);
-    if (0 != read_resp(tcp_buf, size_buf, DEFAULT_TIMEOUT, ">")) {
+    send_cmd(cmd, DEFAULT_TIMEOUT, ">");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
@@ -512,9 +652,11 @@ int GPRS::send_tcp_data(unsigned char *data, int len, char *tcp_buf, int size_bu
     for (int i = 0; i < len; i++) {
         uart_poll_out(gsm_dev, data[i]);
     }
+
+    prepare_for_rx(timeout, NULL);
+    k_sleep(K_SECONDS(timeout));
     // The response could take longer than 7 seconds, it depends on the connection to the server
-    read_resp(tcp_buf, size_buf, timeout, NULL);
-    if (NULL == strstr(tcp_buf, "OK")) {
+    if (NULL == strstr(resp_buf, "OK")) {
         return MODEM_RESPONSE_ERROR;
     }
     // If the response is as expected
@@ -529,41 +671,17 @@ void GPRS::clear_buffer(void)
     for (int i = 0; i < 1000 && (uart_poll_in(gsm_dev, &rec_char) == 0); i++) {;}
 }
 
-int GPRS::check_ssl_cert(const char *filename, int filesize, char *resp_buf, int size_buf)
+int GPRS::reset(void)
 {
-    char cmd[64];
-    snprintf(cmd, sizeof(cmd), "AT+FSFLSIZE=%s", filename);
-    send_cmd(cmd);
-
-    char resp[64];
-    snprintf(resp, sizeof(resp), "FSFLSIZE: %d", filesize);
-
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, resp)) {
+    send_cmd("AT+CFUN=0", DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
-    // If the response is as expected
-    return MODEM_RESPONSE_OK;
-}
-
-int GPRS::load_ssl(const char *filename, const char *cert, int filesize, char *resp_buf, int size_buf)
-{
-    char cmd[64];
-    snprintf(cmd, sizeof(cmd), "AT+FSCREATE=%s", filename);
-    send_cmd(cmd);
-
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
-        return MODEM_RESPONSE_ERROR;
-    }
-
-    snprintf(cmd, sizeof(cmd), "AT+FSWRITE=%s,0,%d,5", filename, filesize);
-    send_cmd(cmd);
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, ">")) {
-        return MODEM_RESPONSE_ERROR;
-    }
-
-    send_cmd(cert);
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    send_cmd("AT+CFUN=1,1", 5, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
@@ -571,15 +689,17 @@ int GPRS::load_ssl(const char *filename, const char *cert, int filesize, char *r
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::reset(char *resp_buf, int size_buf)
+int GPRS::init_sms(void)
 {
-    send_cmd("AT+CFUN=0");
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    send_cmd("AT+CMGF=1", DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
-    send_cmd("AT+CFUN=1,1");
-    if (0 != read_resp(resp_buf, size_buf, 5, "OK")) {
+    send_cmd("AT+CNMI=2,1,0,0,0", DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
@@ -587,27 +707,13 @@ int GPRS::reset(char *resp_buf, int size_buf)
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::init_sms(char *resp_buf, int size_buf)
-{
-    send_cmd("AT+CMGF=1");
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
-        return MODEM_RESPONSE_ERROR;
-    }
-
-    send_cmd("AT+CNMI=2,1,0,0,0");
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
-        return MODEM_RESPONSE_ERROR;
-    }
-
-    // If the responses are as expected
-    return MODEM_RESPONSE_OK;
-}
-
-int GPRS::check_new_sms(char *resp_buf, int size_buf)
+int GPRS::check_new_sms(void)
 {
     char *s;
     int sms_location = 0;
-    read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, NULL);
+
+    // Prepare for reception
+    prepare_for_rx(DEFAULT_TIMEOUT, NULL);
     if (0 != strlen(resp_buf)) {
         s = strstr(resp_buf, "+CMTI");
         if (NULL == s) {
@@ -619,60 +725,68 @@ int GPRS::check_new_sms(char *resp_buf, int size_buf)
     return MODEM_RESPONSE_ERROR; // No response
 }
 
-int GPRS::get_sms(int index, char* message, int length_message)
+int GPRS::get_sms(int index)
 {
     // Read a text message from the message storage area at the specified index
     char cmd[64];
     snprintf(cmd, sizeof(cmd), "AT+CMGR=%d", index);
-    send_cmd(cmd);
-    read_resp(message, length_message, DEFAULT_TIMEOUT, NULL);
+    send_cmd(cmd, DEFAULT_TIMEOUT, NULL);
+    k_sleep(K_SECONDS(1));
+    resp_buf[current_index] = '\0';
     return MODEM_RESPONSE_ERROR; // To be changed in future
 }
 
-int GPRS::send_get_request(char* url, char *resp_buf, int size_buf)
+int GPRS::send_get_request(char* url)
 {
     char cmd[64];
-    send_cmd("AT+HTTPINIT");
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    send_cmd("AT+HTTPINIT", DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
-    send_cmd("AT+HTTPPARA=\"CID\",1");
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    send_cmd("AT+HTTPPARA=\"CID\",1", DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
-    send_cmd("AT+HTTPSSL=1");
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    send_cmd("AT+HTTPSSL=1", DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
-    send_cmd("AT+HTTPPARA=\"REDIR\",1");
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    send_cmd("AT+HTTPPARA=\"REDIR\",1", DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
     snprintf(cmd, sizeof(cmd), "AT+HTTPPARA=\"URL\",\"%s\"", url);
-    send_cmd(cmd);
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    send_cmd(cmd, DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
-    send_cmd("AT+HTTPACTION=0");
-    if (0 != read_resp(resp_buf, size_buf, 5, "+HTTPACTION")) {
+    send_cmd("AT+HTTPACTION=0", 5, "+HTTPACTION");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
-    send_cmd("AT+HTTPREAD");
+    send_cmd("AT+HTTPREAD", DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
 
     // If the responses are as expected
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::bt_power_on(char *resp_buf, int size_buf)
+int GPRS::bt_power_on(void)
 {
-    send_cmd("AT+BTPOWER=1");
-    read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, NULL);
+    send_cmd("AT+BTPOWER=1", DEFAULT_TIMEOUT, NULL);
+    k_sleep(K_SECONDS(1));
     if ((NULL != strstr(resp_buf, "OK")) ||
         (NULL != strstr(resp_buf, "ERROR"))) {
         return MODEM_RESPONSE_OK; // Connection success
@@ -680,31 +794,33 @@ int GPRS::bt_power_on(char *resp_buf, int size_buf)
     return MODEM_RESPONSE_ERROR;
 }
 
-int GPRS::accept_bt(char *resp_buf, int size_buf)
+int GPRS::accept_bt(void)
 {
-    send_cmd("AT+BTACPT=1");
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    send_cmd("AT+BTACPT=1", DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::accept_bt_pair(char *resp_buf, int size_buf)
+int GPRS::accept_bt_pair(void)
 {
-    send_cmd("AT+BTPAIR=1,1");
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    send_cmd("AT+BTPAIR=1,1", DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::send_bt_data(unsigned char *data, int len, char *resp_buf, int size_buf)
+int GPRS::send_bt_data(unsigned char *data, int len)
 {
     char cmd[64];
     snprintf(cmd, sizeof(cmd), "AT+BTSPPSEND=%d", len);
-    send_cmd(cmd);
-
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, ">")) {
+    send_cmd(cmd, DEFAULT_TIMEOUT, ">");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
@@ -713,7 +829,9 @@ int GPRS::send_bt_data(unsigned char *data, int len, char *resp_buf, int size_bu
         uart_poll_out(gsm_dev, data[i]);
     }
 
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    prepare_for_rx(DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
@@ -721,21 +839,23 @@ int GPRS::send_bt_data(unsigned char *data, int len, char *resp_buf, int size_bu
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::check_bt_host(const char *host, char *resp_buf, int size_buf)
+int GPRS::check_bt_host(const char *host)
 {
-    send_cmd("AT+BTHOST?");
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, host)) {
+    send_cmd("AT+BTHOST?", DEFAULT_TIMEOUT, host);
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::change_bt_host(const char *host, char *resp_buf, int size_buf)
+int GPRS::change_bt_host(const char *host)
 {
     char cmd[64];
     snprintf(cmd, sizeof(cmd), "AT+BTHOST=%s", host);
-    send_cmd(cmd);
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
+    send_cmd(cmd, DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
     return MODEM_RESPONSE_OK;
@@ -743,8 +863,7 @@ int GPRS::change_bt_host(const char *host, char *resp_buf, int size_buf)
 
 //////// THIS IS THE END OF FUNCTIONS CURRENTLY IN USE ////////////
 
-
-int GPRS::send_sms(char *number, char *data, char *resp_buf, int size_buf)
+int GPRS::send_sms(char *number, char *data)
 {
     char cmd[64];
 
@@ -754,9 +873,9 @@ int GPRS::send_sms(char *number, char *data, char *resp_buf, int size_buf)
     }
 
     snprintf(cmd, sizeof(cmd), "AT+CMGS=\"%s\"", number);
-    send_cmd(cmd);
-
-    if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, ">")) {
+    send_cmd(cmd, DEFAULT_TIMEOUT, ">");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
@@ -773,7 +892,8 @@ int GPRS::delete_sms(int index)
 {
     char cmd[32];
     snprintf(cmd, sizeof(cmd), "AT+CMGD=%d", index);
-    send_cmd(cmd);
+    send_cmd(cmd, DEFAULT_TIMEOUT, "OK");
+    k_sleep(K_SECONDS(1));
     return MODEM_RESPONSE_OK;
 }
 
@@ -782,11 +902,12 @@ int GPRS::answer(void)
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::call_up(char *number, char *resp_buf, int size_buf)
+int GPRS::call_up(char *number)
 {
-    send_cmd("AT+COLP=1");
+    send_cmd("AT+COLP=1", 5, "OK");
+    k_sleep(K_SECONDS(1));
 
-    if (0 != read_resp(resp_buf, size_buf, 5, "OK")) {
+    if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
@@ -794,14 +915,15 @@ int GPRS::call_up(char *number, char *resp_buf, int size_buf)
     return MODEM_RESPONSE_OK;
 }
 
-bool GPRS::get_location(float *latitude, float *longitude, char *resp_buf, int size_buf)
+bool GPRS::get_location(float *latitude, float *longitude)
 {
     char *location[10];
     const char s[2] = ",";
     char *token;
     int i = 0;
-    send_cmd("AT+CIPGSMLOC=1,1");
-    if (0 == read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "$$+CIPGSMLOC: ")) {
+    send_cmd("AT+CIPGSMLOC=1,1", DEFAULT_TIMEOUT, "$$+CIPGSMLOC: ");
+    k_sleep(K_SECONDS(1));
+    if (ack_received == false) {
         token = strtok(resp_buf, s);
         while (token != NULL) {
             location[i] = token;

--- a/src/SIM800-AT.cpp
+++ b/src/SIM800-AT.cpp
@@ -30,7 +30,6 @@ int GPRS::request_data(void)
 
 int GPRS::read_resp(char *resp_buf, int size_buf, int time_out, const char *ack_message)
 {
-
     Timer t;
     t.start();
 
@@ -126,7 +125,7 @@ int GPRS::set_pin(const char* pin, char *resp_buf, int size_buf)
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::enable_ssl(const char *filename, char *resp_buf, int size_buf)
+int GPRS::ssl_set_cert(const char *filename, char *resp_buf, int size_buf)
 {
     char cmd[64];
     snprintf(cmd, sizeof(cmd), "AT+SSLSETCERT=%s,ABC", filename);
@@ -135,6 +134,12 @@ int GPRS::enable_ssl(const char *filename, char *resp_buf, int size_buf)
         return MODEM_RESPONSE_ERROR;
     }
 
+    // If the response is as expected
+    return MODEM_RESPONSE_OK;
+}
+
+int GPRS::enable_ssl(char *resp_buf, int size_buf)
+{
     send_cmd("AT+CIPSSL=1");
     if (0 != read_resp(resp_buf, size_buf, DEFAULT_TIMEOUT, "OK")) {
         return MODEM_RESPONSE_ERROR;


### PR DESCRIPTION
What does this PR do?
The UART reception from the GSM modem is now handled using serial interrupts. The previous method using UART polling was unreliable in cases of multithreading. Few bytes could be lost when the UART is not read in time, when other threads are running.
The interrupt service routine is implemented for reception of responses from SIM800 after a command is sent to the modem. 
A global buffer "resp_buf[]" will store the received bytes, which can be accessed by other modules. The ISR can be used by specifying an expected acknowledgement string and a timeout. If a NULL is used as the expected acknowledgement string, the ISR will receive data until the buffer is full or the specified timeout occurs.


Where should the reviewer start?
SIM800-AT.cpp

Any background context you want to provide?
The interrupt driven code is only implemented for the Zephyr framework now. The mbed version will be done in a separate PR. 
