### PR TITLE
Make the UART buffer size configurable

### DIFF
--- a/src/SIM800-AT.h
+++ b/src/SIM800-AT.h
@@ -33,15 +33,15 @@
 #define MODEM_RESPONSE_OK 0
 #define MODEM_RESPONSE_ERROR -1
 
-#define BUF_SIZE_DEFAULT 200
-
 #ifdef __ZEPHYR__
 
-/** Initializes the UART interrupts
- * The ISR call-back function read_resp() is configured here.
- * No arguments are passed to the ISR as of now.
+/** Initializes the UART interrupts and the buffer.
+ * The ISR call-back function read_resp() is configured here and no arguments are passed to the ISR
+ * as of now. Also char buffer for collecting the UART data and it's size are set here.
+ *  @param buf Pointer to the buffer that will store the received UART data.
+ *  @param size_buf Size of the UART buffer
  */
-void init_modem(void);
+void init_modem(char *buf, uint32_t size_buf);
 
 #endif // #ifdef __ZEPHYR__
 


### PR DESCRIPTION
What does this PR do?
Implement passing external buffer handles to the SIM800 library.
The library now has a way to access an external buffer, which can be used to store the bytes received over the UART.
The buffer size may be configured at compile time (board specific) using a Kconfig in the calling module. The buffer size depends on the flash page size of each MCU, as required for OTA binary transfer.

Where should the reviewer start?
- SIM800-AT-Zephyr.cpp
