### PR TITLE
Configure delay for FTP-read from SIM800 RAM

### DIFF
--- a/src/Kconfig
+++ b/src/Kconfig
@@ -1,0 +1,7 @@
+
+# Copyright (c) 2021 Scene Connect Ltd & Connected Energy Technologies Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+config FTP_READ_WAIT
+    int "Wait time in milliseconds to FTP transfer a flash page."
+    default 1000

--- a/src/SIM800-AT-Zephyr.cpp
+++ b/src/SIM800-AT-Zephyr.cpp
@@ -1,5 +1,5 @@
 /* SIM800_AT firmware
- * Copyright (c) 2016-2019 Connected Energy Technologies Ltd
+ * Copyright (c) 2016-2021 Connected Energy Technologies Ltd
  * (www.connectedenergy.net)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1071,7 +1071,7 @@ int GPRS::ftp_read_from_ram(int length, int offset)
     char cmd[64];
     snprintf(cmd, sizeof(cmd), "AT+FTPEXTGET=3,%d,%d", offset, length);
     send_cmd(cmd, 2, NULL);
-    k_sleep(K_SECONDS(1));
+    k_sleep(K_MSEC(CONFIG_FTP_READ_WAIT));
 
     return MODEM_RESPONSE_OK;
 }

--- a/src/SIM800-AT.h
+++ b/src/SIM800-AT.h
@@ -1,5 +1,5 @@
 /* SIM800_AT firmware
- * Copyright (c) 2016-2019 Connected Energy Technologies Ltd
+ * Copyright (c) 2016-2021 Connected Energy Technologies Ltd
  * (www.connectedenergy.net)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -62,13 +62,13 @@ public:
 
     Serial gprsSerial;
 
-    /** 
-     * Reads the server response through serial port. The function is used in 2 ways. 
+    /**
+     * Reads the server response through serial port. The function is used in 2 ways.
      * 1) To read-out the buffer, in which case, no return is actually expected.
      * 2) To read-out and also check the response against an expected message.
      * @param time_out Maximum time (seconds) spent for reading the serial port
      * @param ack_message Pointer to a string containing the expected message.
-     * This argument should be NULL, if no acknowledgment-check is needed. 
+     * This argument should be NULL, if no acknowledgment-check is needed.
      * @return While checking the response against an expected message,
      * Invalid response : -1
      * Valid response   : 0
@@ -393,6 +393,8 @@ public:
      * Implements the FTPEXTGET file read from the SIM800 modem using the command,
      * for example, AT+FTPEXTGET=3,0,128.
      * The read bytes will be available in the buffer "resp_buf" after a successful read operation.
+     * The wait time after sending the read command is configurable at compile-time
+     * (CONFIG_FTP_READ_WAIT).
      * A response for the request AT+FTPEXTGET=3,0,128 will always start with
      * 2 bytes 0x0D 0x0A followed by "+FTPEXTGET: 3,128" and then 2 additional bytes 0x0D 0x0A.
      * Then the actual bytes come and then ends with 6 bytes (0x0d 0x0a 0x4f 0x4b 0x0d 0x0a).


### PR DESCRIPTION
The PR adds a Kconfig for the library, to make the wait time for FTP-read from RAM configurable at compile time (CONFIG_FTP_READ_WAIT).