### PR TITLE
Improve error checking in send_tcp_data

### DIFF
--- a/src/SIM800-AT-Zephyr.cpp
+++ b/src/SIM800-AT-Zephyr.cpp
@@ -672,9 +672,17 @@ int GPRS::send_tcp_data(unsigned char *data, int len, uint8_t timeout)
 
     prepare_for_rx(timeout, NULL);
     k_sleep(K_SECONDS(timeout));
-    // The response could take longer than 7 seconds, it depends on the connection to the server
-    if (NULL == strstr(resp_buf, "OK")) {
-        return MODEM_RESPONSE_ERROR;
+
+
+    // The response could take a long time, which depends on the connection to the server
+    if (NULL == strstr(resp_buf, "SEND OK")) {
+        if (NULL == strstr(resp_buf, "+CME ERROR")) {
+            return MODEM_RESPONSE_ERROR;
+        }
+        else {
+            // An error related to mobile equipment or network
+            return MODEM_CME_ERROR;
+        }
     }
     // If the response is as expected
     return MODEM_RESPONSE_OK;

--- a/src/SIM800-AT.h
+++ b/src/SIM800-AT.h
@@ -32,6 +32,7 @@
 #define DEFAULT_TIMEOUT 3
 #define MODEM_RESPONSE_OK 0
 #define MODEM_RESPONSE_ERROR -1
+#define MODEM_CME_ERROR -2
 
 #ifdef __ZEPHYR__
 


### PR DESCRIPTION
This is a small PR to check if any +CME ERROR is received instead of a 'SEND OK' response from the GSM network, to know if any error related to mobile equipment or network.