### PR TITLE
Granular timeouts

### DIFF
--- a/src/Kconfig
+++ b/src/Kconfig
@@ -2,10 +2,6 @@
 # Copyright (c) 2021 Scene Connect Ltd & Connected Energy Technologies Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-config FTP_READ_WAIT
-    int "Wait time in milliseconds to FTP transfer a flash page."
-    default 500
-
 config SIM800_TCP_QUICKSEND
     bool "Use TCP quicksend."
     default n

--- a/src/SIM800-AT-Zephyr.cpp
+++ b/src/SIM800-AT-Zephyr.cpp
@@ -35,7 +35,12 @@ int GPRS::ip_rx_data(void)
 {
     // The length of output data can not exceed 1460 bytes at a time,
     // based on SIM800 Series_AT Command Manual.
-    send_cmd("AT+CIPRXGET=2,1460", DEFAULT_TIMEOUT, NULL);
+    char cmd[18];
+    snprintf(cmd, sizeof(cmd), "AT+CIPRXGET=2,%d", resp_buf_len);
+    // We assume the worst case transfer speed of 9.6kbps, equivalent
+    // to ~1byte/ms. We also append a margin of 55ms.
+    int timeout = resp_buf_len + 55;
+    send_cmd(cmd, timeout, NULL);
     uint16_t tcp_packet_len;
     //LOG_DBG("   Got reply after CIPRXGET:%s", resp_buf+2);
     sscanf(resp_buf, " +CIPRXGET: 2,%hu,0", &tcp_packet_len);

--- a/src/SIM800-AT-Zephyr.cpp
+++ b/src/SIM800-AT-Zephyr.cpp
@@ -302,29 +302,28 @@ int GPRS::setup_clock(void)
 int GPRS::setup_bearer(const char* apn, const char* user, const char* pass)
 {
     // Set the type of Internet connection as GPRS
-    char cmd[64];
-    send_cmd("AT+SAPBR=3,1,Contype,GPRS", 100, "OK");
+    char cmd[50];
+    send_cmd("AT+SAPBR=3,1,Contype,GPRS", DEFAULT_TIMEOUT, "OK");
     if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
-
     // Set the access point name string
     snprintf(cmd, sizeof(cmd), "AT+SAPBR=3,1,APN,\"%s\"", apn);
-    send_cmd(cmd, 100, "OK");
+    send_cmd(cmd, DEFAULT_TIMEOUT, "OK");
     if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
     // Set the user name for APN
     snprintf(cmd, sizeof(cmd), "AT+SAPBR=3,1,USER,\"%s\"", user);
-    send_cmd(cmd, 100, "OK");
+    send_cmd(cmd, DEFAULT_TIMEOUT, "OK");
     if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
 
     // Set the password for APN
     snprintf(cmd, sizeof(cmd), "AT+SAPBR=3,1,PWD,\"%s\"", pass);
-    send_cmd(cmd, 100, "OK");
+    send_cmd(cmd, DEFAULT_TIMEOUT, "OK");
     if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
@@ -334,8 +333,8 @@ int GPRS::setup_bearer(const char* apn, const char* user, const char* pass)
 
 int GPRS::enable_bearer(void)
 {
-    send_cmd("AT+SAPBR=1,1", 1500, NULL); // Response time can be upto 85 seconds
-    if (NULL != strstr(resp_buf, "OK")) {
+    send_cmd("AT+SAPBR=1,1", 3500, "OK"); // Response time can be upto 85 seconds
+    if (ack_received) {
         return MODEM_RESPONSE_OK;
     }
     // Returns with ERROR if it's already open or if actually an error

--- a/src/SIM800-AT-Zephyr.cpp
+++ b/src/SIM800-AT-Zephyr.cpp
@@ -487,19 +487,12 @@ int GPRS::attach_gprs(void)
 
 int GPRS::enable_get_data_manually(void)
 {
-    // Startup single IP connection
-    send_cmd("AT+CIPMUX=0", DEFAULT_TIMEOUT, "OK");
+    // CIPMUX=0 -> set single IP connection
+    // CIPRXGET=1 -> poll for RX data.
+    send_cmd("AT+CIPMUX=0;+CIPRXGET=1", DEFAULT_TIMEOUT, "OK");
     if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }
-
-    //Enable getting data from network manually.
-    send_cmd("AT+CIPRXGET=1", DEFAULT_TIMEOUT, "OK");
-    if (ack_received == false) {
-        return MODEM_RESPONSE_ERROR;
-    }
-
-    // If the responses are as expected
     return MODEM_RESPONSE_OK;
 }
 

--- a/src/SIM800-AT-Zephyr.cpp
+++ b/src/SIM800-AT-Zephyr.cpp
@@ -182,6 +182,10 @@ int GPRS::init(void)
     // set, so we don't consider missing ACK an error.
     send_cmd("AT+CSCLK=0", DEFAULT_TIMEOUT, "OK");
 
+    // Try to use the maximum GPRS class (12) for SIM800, in which 4 TX
+    // slots and 4 RX slots are being used. We don't mind errors here.
+    send_cmd("AT+CGMSCLASS=12", DEFAULT_TIMEOUT, "OK");
+
     return MODEM_RESPONSE_OK;
 }
 

--- a/src/SIM800-AT-Zephyr.cpp
+++ b/src/SIM800-AT-Zephyr.cpp
@@ -1048,22 +1048,23 @@ int GPRS::read_ftp_file(const char *file_name, int length, int offset)
     return MODEM_RESPONSE_OK;
 }
 
-int GPRS::ftp_get_to_ram(const char *server, const char *user, const char *pw, const char *file_name,
-                    const char *file_path)
+int GPRS::ftp_get_to_ram(const char *server, const char *user, const char *pw,
+                         const char *file_name, const char *file_path)
 {
     if (ftp_init(server, user, pw, file_name, file_path) != MODEM_RESPONSE_OK) {
         return MODEM_RESPONSE_ERROR;
     }
 
     // Open the FTP session
-    send_cmd("AT+FTPEXTGET=1", 500, NULL); //Takes more than 1 minute to download
+    send_cmd("AT+FTPEXTGET=1", DEFAULT_TIMEOUT, NULL);
     if (NULL == strstr(resp_buf, "OK")) {
         return MODEM_RESPONSE_ERROR;
     }
-    // After this, the caller needs to wait until the response "+FTPEXTGET: 1,0" is received,
-    // which indicates that the downloading is successful.
+    // The caller needs to wait until the response "+FTPEXTGET: 1,0"
+    // is received, which indicates that the downloading is
+    // successful.
+    prepare_for_rx(90000, "EXTGET: 1,0");
 
-    // If the response is as expected
     return MODEM_RESPONSE_OK;
 }
 

--- a/src/SIM800-AT-Zephyr.cpp
+++ b/src/SIM800-AT-Zephyr.cpp
@@ -182,8 +182,15 @@ int GPRS::test_uart()
 
 int GPRS::init(void)
 {
-    send_cmd("AT", 300, "OK");
-    send_cmd("AT", 300, "OK");
+    // On higher baud rates, we might need to bang AT a number of
+    // times, to train the modem's autobad feature.
+    int i = 6;
+    while(i--) {
+        send_cmd("AT", 300, "OK");
+        if (ack_received) {
+            break;
+        }
+    }
     if (!ack_received) {
         return MODEM_RESPONSE_ERROR;
     }
@@ -507,7 +514,7 @@ int GPRS::enable_get_data_manually(void)
 {
     // CIPMUX=0 -> set single IP connection
     // CIPRXGET=1 -> poll for RX data.
-    send_cmd("AT+CIPMUX=0;+CIPRXGET=1", DEFAULT_TIMEOUT, "OK");
+    send_cmd("AT+CIPMUX=0;+CIPRXGET=1", DEFAULT_TIMEOUT * 2, "OK");
     if (ack_received == false) {
         return MODEM_RESPONSE_ERROR;
     }

--- a/src/SIM800-AT-Zephyr.cpp
+++ b/src/SIM800-AT-Zephyr.cpp
@@ -137,6 +137,7 @@ void GPRS::send_cmd(const char *cmd, size_t timeout, const char *ack,
 // Resets the necessary variables and enables the Rx interrupt
 void GPRS::prepare_for_rx(size_t timeout, const char *ack)
 {
+    uart_irq_rx_disable(gsm_dev);
     ack_message[0] = '\0';
     // Make the ack_message configurable
     len_ack = 0;

--- a/src/SIM800-AT.h
+++ b/src/SIM800-AT.h
@@ -96,7 +96,7 @@ public:
     int close_tcp_quick(char *resp_buf, int size_buf);
     int detach_gprs(char *resp_buf, int size_buf);
     int disable_bearer(char *resp_buf, int size_buf);
-    int send_tcp_data(unsigned char *data, int len, char *resp_buf, int size_buf, size_t timeout);
+    int send_tcp_data(unsigned char *data, int len, char *resp_buf, int size_buf);
     int reset(char *resp_buf, int size_buf);
     int init_sms(char *resp_buf, int size_buf);
     int check_new_sms(char *resp_buf, int size_buf);
@@ -247,7 +247,7 @@ public:
 
     int detach_gprs(void);
     int disable_bearer(void);
-    int send_tcp_data(const void *data, size_t len, size_t timeout);
+    int send_tcp_data(const void *data, size_t len);
     int reset(void);
     int init_sms(void);
     int check_new_sms(void);

--- a/src/SIM800-AT.h
+++ b/src/SIM800-AT.h
@@ -32,7 +32,7 @@
 #include "stm32l072xx.h" // For the USART_TypeDef declaration
 #endif
 
-#define DEFAULT_TIMEOUT 2
+#define DEFAULT_TIMEOUT 50
 #define MODEM_RESPONSE_OK 0
 #define MODEM_RESPONSE_ERROR -1
 #define MODEM_CME_ERROR -2
@@ -96,7 +96,7 @@ public:
     int close_tcp_quick(char *resp_buf, int size_buf);
     int detach_gprs(char *resp_buf, int size_buf);
     int disable_bearer(char *resp_buf, int size_buf);
-    int send_tcp_data(unsigned char *data, int len, char *resp_buf, int size_buf, uint8_t timeout);
+    int send_tcp_data(unsigned char *data, int len, char *resp_buf, int size_buf, size_t timeout);
     int reset(char *resp_buf, int size_buf);
     int init_sms(char *resp_buf, int size_buf);
     int check_new_sms(char *resp_buf, int size_buf);
@@ -247,7 +247,7 @@ public:
 
     int detach_gprs(void);
     int disable_bearer(void);
-    int send_tcp_data(void *data, size_t len, uint8_t timeout);
+    int send_tcp_data(const void *data, size_t len, size_t timeout);
     int reset(void);
     int init_sms(void);
     int check_new_sms(void);
@@ -330,7 +330,7 @@ public:
      * the Rx interrupt will be disabled.
      * @param ack_message Pointer to a string containing the expected acknowledgement.
      */
-    void prepare_for_rx(int timeout, const char *ack);
+    void prepare_for_rx(size_t timeout, const char *ack);
 
     /**
      * Implements FTP session initialisation to be used by FTPGETTOFS as well as FTPEXTGET.
@@ -444,7 +444,8 @@ private:
      * this can only happen if there is a reception at the Rx pin. This is fixed by clearing the buffer.
      * See the implementation of the ISR function "read_resp()" for more details.
      */
-    void send_cmd(const char *cmd, int timeout, const char *ack);
+    void send_cmd(const char *cmd, size_t timeout, const char *ack,
+                  bool no_wait=false);
 #endif
 
     void clear_buffer(void);


### PR DESCRIPTION
Lots of timing corrections and speed optimisations.

The main issue addresed were timeouts on TCP receive, occuring due to the configured timeouts expressed as seconds, which would inccur catastrophic cancelation on integer division by 1000 and having the receive interrupt bailing out early even though there was still lots of time left to receive.

Fixing this led to an overhaul of all the wait states used in the library and improvements in many routines (interrupt handler, GPRS setup, autobaud setup, FTP page reads, etc).

All these fixes make the library much more robust and faster - it has been tested on a CloudSolar device working properly at up to 115kbps; its GSM loop finishes in about 15 seconds after network registration (almost 18 seconds after system startup in best case) and an MQTT OTA update message can be processed and flashed in around 50 seconds since system startup. Test images for these are here: https://drive.google.com/drive/u/0/folders/1x9BJGyX0uNrS_BwMD0gFPxxmteaw86eR . There will be a related CloudSolar PR incoming.

Somewhat related: Next steps for improvement (which might still get caugt into this PR) would be removal of MBED code, as the tree has been tagged and we get a pointer where MBED code still lives in the history of the repo (and e.g CloudSolar MBED code uses hardcoded commit hashes anyway and knows what version of the library it uses). This will add a bit of sanity into the header file, which is terribly hard to follow at the moment.