### PR TITLE
Make ip_rx_data() more robust to edge cases.

### DIFF
--- a/src/SIM800-AT.h
+++ b/src/SIM800-AT.h
@@ -291,6 +291,14 @@ public:
     int ip_rx_data(void);
 
     /**
+     * Strip the modem response from the start of a buffer and move the rest
+     * of the contents to the start of the buffer
+     * @param count The number of bytes after the strip to move to start
+     * @return The number of bytes stripped
+     */
+    size_t strip_modem_response(size_t count);
+
+    /**
      * Check the current bearer status sending the command "AT+SAPBR=2,1"
      * to the GSM modem.
      * @return Returns -1 if invalid or no response from the modem.


### PR DESCRIPTION
- Dont allow packet lengths SIM800 cant deal with. If you request 0 or >1460 you get an error response which this function is not prepared for.
- ~Return TCP avail so that caller knows there is still data available even though only a fixed amount may be delivered due to buffer constraints.~ Return the amount of data the application can consume from the buffer, with the modem response accounted for. It becomes the applications responsibility to provide a buffer big enough for all the data it might need.
- Make scanning for the CIPRXGET independent of position as unexpected behaviour when SIM800_ACK_TCP_TX=y